### PR TITLE
metadata.json: Support GNOME Shell 48

### DIFF
--- a/start-overlay-in-application-view@Hex_cz/metadata.json
+++ b/start-overlay-in-application-view@Hex_cz/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ], 
   "url": "https://github.com/Hexcz/Start-Overlay-in-Application-View-for-Gnome-40-", 
   "uuid": "start-overlay-in-application-view@Hex_cz", 


### PR DESCRIPTION
This seems to continue to work as expected here after manually enabling it.