### PR TITLE
Show apps on startup

### DIFF
--- a/start-overlay-in-application-view@Hex_cz/extension.js
+++ b/start-overlay-in-application-view@Hex_cz/extension.js
@@ -1,4 +1,5 @@
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Overview from 'resource:///org/gnome/shell/ui/overview.js';
 
 export default class StartOverlayInAppViewExtension extends Extension {
@@ -20,6 +21,8 @@ export default class StartOverlayInAppViewExtension extends Extension {
             else
                 this.showApps();
         };
+        
+        Main.overview.showApps()
     }
 
     disable() {


### PR DESCRIPTION
Fixes #11.

This feels a bit like a bludgeon; I feel like there should be a way to ensure it's showing after the actual startup instead of just as soon as the extension is loaded.